### PR TITLE
app配下のlayout.tsxの修正

### DIFF
--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,11 @@
+type Props = {
+  children: React.ReactNode;
+};
+
+const PublicLayout: React.FC<Props> = async (props) => {
+  return (
+    <main className="mx-4 mt-2 max-w-3xl md:mx-auto">{props.children}</main>
+  );
+};
+
+export default PublicLayout;

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,3 +1,11 @@
+import type { Metadata } from "next";
+import "../globals.css";
+
+export const metadata: Metadata = {
+  title: "TASQ",
+  description: "...",
+};
+
 type Props = {
   children: React.ReactNode;
 };

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { DevAuthButton } from "@/app/_components/DevAuthButton";
+const Page: React.FC = () => {
+  return (
+    <div>
+      <div className="text-2xl font-bold">Main</div>
+      <div className="mt-4 ml-2 flex flex-col gap-y-2">
+        <Link href="/signup">サインアップ</Link>
+        <Link href="/login">ログイン</Link>
+        <Link href="/api/playground/tasks">APIテスト（public）</Link>
+        <Link href="/api/playground/users">APIテスト（private）</Link>
+        <Link href="/settings">設定（private）</Link>
+        <div className="mt-4">
+          <DevAuthButton />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default Page;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,9 +13,7 @@ type Props = {
 const RootLayout: React.FC<Props> = async (props) => {
   return (
     <html lang="ja">
-      <body>
-        <main className="mx-4 mt-2 max-w-3xl md:mx-auto">{props.children}</main>
-      </body>
+      <body>{props.children}</body>
     </html>
   );
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,22 @@
-import { redirect } from "next/navigation";
+import Link from "next/link";
+import { DevAuthButton } from "@/app/_components/DevAuthButton";
 
 const Page: React.FC = () => {
-  redirect("/login");
+  return (
+    <div className="mx-4 mt-2 max-w-3xl md:mx-auto">
+      <div className="text-2xl font-bold">Main</div>
+      <div className="mt-4 ml-2 flex flex-col gap-y-2">
+        <Link href="/signup">サインアップ</Link>
+        <Link href="/login">ログイン</Link>
+        <Link href="/api/playground/tasks">APIテスト（public）</Link>
+        <Link href="/api/playground/users">APIテスト（private）</Link>
+        <Link href="/settings">設定（private）</Link>
+        <div className="mt-4">
+          <DevAuthButton />
+        </div>
+      </div>
+    </div>
+  );
 };
 
 export default Page;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,21 +1,7 @@
-import Link from "next/link";
-import { DevAuthButton } from "@/app/_components/DevAuthButton";
+import { redirect } from "next/navigation";
+
 const Page: React.FC = () => {
-  return (
-    <div>
-      <div className="text-2xl font-bold">Main</div>
-      <div className="mt-4 ml-2 flex flex-col gap-y-2">
-        <Link href="/signup">サインアップ</Link>
-        <Link href="/login">ログイン</Link>
-        <Link href="/api/playground/tasks">APIテスト（public）</Link>
-        <Link href="/api/playground/users">APIテスト（private）</Link>
-        <Link href="/settings">設定（private）</Link>
-        <div className="mt-4">
-          <DevAuthButton />
-        </div>
-      </div>
-    </div>
-  );
+  redirect("/login");
 };
 
 export default Page;


### PR DESCRIPTION
## 実装概要
 app/layout.tsxのtailwindcssが原因でログイン後のページにサイドバーとコンテンツの間に不要な余白が発生していたため(public)配下にlayout.tsxおよびpage.tsxを移動しました。
ログイン後のページでスタイリングが崩れている場合がありますので、お手数ですが確認していただきたいです。🙇‍♂️

## チェック項目
- [x] 新規画面・機能の場合に Repro イベントを追加していること- [ ] コンソールにログが残ってないこと
- [x] 使用していない変数、インポートが残ってないこと

## テスト項目(挙動などのチェック)

- [x] ログイン前後のページでスタイリングをきりわける


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * パブリックページ用の新しいレイアウトコンポーネントを追加しました。
  * メインページに「Main」見出しと複数のナビゲーションリンクを追加しました。
  * トップページの表示にレスポンシブなマージンと最大幅のスタイルを適用しました。

* **変更**
  * アプリ全体のレイアウト構造を簡素化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->