### PR TITLE
各ページのページタイトル部分を共通化

### DIFF
--- a/src/app/(private)/settings/page.tsx
+++ b/src/app/(private)/settings/page.tsx
@@ -4,6 +4,7 @@ import { authenticateSupabaseUser } from "@/app/_libs/authenticateUser";
 
 // UIコンポーネント・アイコン
 import ProfileEditorView from "./_components/ProfileSettingView";
+import { PageTitle } from "@/app/_components/PageTitle";
 
 // 型定義・バリデーションスキーマ
 import type { User as SupabaseUser } from "@supabase/supabase-js";
@@ -49,7 +50,7 @@ const toSelfProfile = (user: AppUser, email: string): SelfProfile => {
 const withPageLayout = (content: React.ReactNode) => (
   <div className="mb-4 flex justify-center">
     <div className="w-full max-w-[460px]">
-      <h1 className="mb-8 text-center text-3xl font-bold">プロフィール設定</h1>
+      <PageTitle>プロフィール設定</PageTitle>
       {content}
     </div>
   </div>

--- a/src/app/(public)/login/_components/LoginPage.tsx
+++ b/src/app/(public)/login/_components/LoginPage.tsx
@@ -13,6 +13,7 @@ import { FormTextField } from "@/app/_components/FormTextField";
 import { FormErrorMessage } from "@/app/_components/FormErrorMessage";
 import { LuSend } from "react-icons/lu";
 import { Loader2Icon } from "lucide-react";
+import { PageTitle } from "@/app/_components/PageTitle";
 
 // 型定義・バリデーションスキーマ
 import type { LoginRequest } from "@/app/_types/LoginRequest";
@@ -88,7 +89,7 @@ export const LoginPage: React.FC<Props> = (props) => {
   return (
     <div className="flex justify-center">
       <div className="w-full max-w-[460px]">
-        <h1 className="mb-8 text-center text-3xl font-bold">ログイン</h1>
+        <PageTitle>ログイン</PageTitle>
 
         <form
           noValidate

--- a/src/app/(public)/signup/_components/SignupPage.tsx
+++ b/src/app/(public)/signup/_components/SignupPage.tsx
@@ -9,6 +9,7 @@ import { useForm, FormProvider } from "react-hook-form";
 import { Button } from "@/app/_components/ui/button";
 import { FormTextField } from "@/app/_components/FormTextField";
 import { FormErrorMessage } from "@/app/_components/FormErrorMessage";
+import { PageTitle } from "@/app/_components/PageTitle";
 
 import { LuSend } from "react-icons/lu";
 import { Loader2Icon } from "lucide-react";
@@ -125,7 +126,7 @@ export const SignupPage: React.FC = () => {
   return (
     <div className="flex justify-center">
       <div className="w-full max-w-[460px]">
-        <h1 className="mb-8 text-center text-3xl font-bold">サインアップ</h1>
+        <PageTitle>サインアップ</PageTitle>
         <form
           className="space-y-4"
           noValidate

--- a/src/app/_components/AlreadyLoggedInPage.tsx
+++ b/src/app/_components/AlreadyLoggedInPage.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from "@/app/_components/ui/button";
 import { logoutAction } from "@/app/_actions/logoutAction";
+import { PageTitle } from "./PageTitle";
 
 type Props = {
   action: string;
@@ -13,7 +14,7 @@ export const AlreadyLoggedInPage: React.FC<Props> = (props) => {
   return (
     <div className="flex justify-center">
       <div className="w-full max-w-[460px]">
-        <h1 className="mb-8 text-center text-3xl font-bold">{action}</h1>
+        <PageTitle>{action}</PageTitle>
         <div>
           <p className="mt-3 text-sm break-all">
             現在、<span className="mr-1 font-bold">{email}</span>

--- a/src/app/_components/ErrorPage.tsx
+++ b/src/app/_components/ErrorPage.tsx
@@ -1,4 +1,5 @@
 import { FaGhost } from "react-icons/fa";
+import { PageTitle } from "./PageTitle";
 
 type Props = {
   message: string;
@@ -9,11 +10,11 @@ export const ErrorPage: React.FC<Props> = (props) => {
   return (
     <div className="flex justify-center">
       <div className="w-full max-w-[460px]">
-        <h1 className="mb-8 text-center text-3xl font-bold">
+        <PageTitle>
           <FaGhost className="mr-2 inline-block" />
           ERROR
           <FaGhost className="ml-2 inline-block" />
-        </h1>
+        </PageTitle>
         <div>
           <p className="mt-3 text-sm break-all text-red-500">{message}</p>
         </div>

--- a/src/app/_components/PageTitle.tsx
+++ b/src/app/_components/PageTitle.tsx
@@ -1,0 +1,7 @@
+interface Props {
+  children: React.ReactNode;
+}
+
+export const PageTitle: React.FC<Props> = ({ children }) => {
+  return <h1 className="mb-8 text-center text-3xl font-bold">{children}</h1>;
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複数ページで共通して利用できる新しいページタイトル用コンポーネントを追加しました。

* **リファクタリング**
  * 設定、ログイン、サインアップ、エラーページなどのタイトル表示を統一されたコンポーネントに置き換え、デザインとコードの一貫性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->