### PR TITLE
学習ログのバックエンド処理の実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 # Claude
 /.claude/settings.local.json
+.mcp.json
 
 # dependencies
 /node_modules

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,6 +5,7 @@
     "Retryable",
     "tasq",
     "turbopack",
+    "uuidv",
     "vercel"
   ],
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,12 @@
 {
-  "cSpell.words": ["fuga", "Retryable", "tasq", "turbopack", "vercel"],
+  "cSpell.words": [
+    "fuga",
+    "modelcontextprotocol",
+    "Retryable",
+    "tasq",
+    "turbopack",
+    "vercel"
+  ],
 
   // VSCode拡張機能 Vitest（vitest.explorer）のための設定
   "vitest.nodeEnv": {
@@ -7,5 +14,6 @@
   },
   "vitest.nodeExecArgs": ["--require", "dotenv/config"],
   "vitest.rootConfig": "vitest.config.ts",
-  "vitest.logLevel": "info"
+  "vitest.logLevel": "info",
+  "postman.settings.dotenv-detection-notification-visibility": false
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,6 +158,14 @@ DIRECT_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 - Custom UI components in `_components/ui/`
 - Responsive design patterns with mobile-first approach
 
+### TypeScript Rules
+- **`any` type is strictly prohibited** in this codebase
+- Always use proper type definitions instead of `any`
+- For database transactions, use `DbClient = PrismaClient | Prisma.TransactionClient`
+- For unknown types, use `unknown` and type guards for safety
+- Use utility types (`Partial<T>`, `Pick<T>`, `Omit<T>`) for complex type manipulations
+- When dealing with external APIs, define proper interfaces or use type assertions with validation
+
 ### Error Handling
 - Centralized error types in `_types/AppErrorCodes.ts`
 - API responses use standardized `ApiResponse<T>` format

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -86,10 +86,13 @@ const supabase = createClient(
   process.env.SB_SERVICE_ROLE_KEY,
 );
 
-// 開発用のテストユーザの定義
+// 開発用のテストユーザの定義（作業の便宜上、意図的にUUIDは固定値を使用）
+// - UUIDv4 第3ブロック先頭 → 4（v4指定）
+// - UUIDv4 第4ブロック先頭 → 8（バリアント指定）
+// - 本番運用では必ず uuid ライブラリで生成したUUIDを使用すること
 const testUsers = [
   {
-    id: "11111111-1111-1111-1111-111111111111",
+    id: "11111111-1111-4111-8111-111111111111",
     email: "user1@example.com",
     password: "##user1",
     name: "構文 誤次郎",
@@ -97,7 +100,7 @@ const testUsers = [
     slackId: "@user1",
   },
   {
-    id: "22222222-2222-2222-2222-222222222222",
+    id: "22222222-2222-4222-8222-222222222222",
     email: "user2@example.com",
     password: "##user2",
     name: "仕様 曖昧子",
@@ -105,7 +108,7 @@ const testUsers = [
     slackId: "@user2",
   },
   {
-    id: "33333333-3333-3333-3333-333333333333",
+    id: "33333333-3333-4333-8333-333333333333",
     email: "user3@example.com",
     password: "##user3",
     name: "保守 絶望太",
@@ -114,7 +117,7 @@ const testUsers = [
   },
   // 追加のテストユーザー（7名）
   {
-    id: "44444444-4444-4444-4444-444444444444",
+    id: "44444444-4444-4444-8444-444444444444",
     email: "user4@example.com",
     password: "##user4",
     name: "実装 速太郎",
@@ -122,7 +125,7 @@ const testUsers = [
     slackId: "@user4",
   },
   {
-    id: "55555555-5555-5555-5555-555555555555",
+    id: "55555555-5555-4555-8555-555555555555",
     email: "user5@example.com",
     password: "##user5",
     name: "設計 美代子",
@@ -130,7 +133,7 @@ const testUsers = [
     slackId: "@user5",
   },
   {
-    id: "66666666-6666-6666-6666-666666666666",
+    id: "66666666-6666-4666-8666-666666666666",
     email: "user6@example.com",
     password: "##user6",
     name: "品質 守",
@@ -138,7 +141,7 @@ const testUsers = [
     slackId: "@user6",
   },
   {
-    id: "77777777-7777-7777-7777-777777777777",
+    id: "77777777-7777-4777-8777-777777777777",
     email: "user7@example.com",
     password: "##user7",
     name: "開発 統括太",
@@ -146,7 +149,7 @@ const testUsers = [
     slackId: "@user7",
   },
   {
-    id: "88888888-8888-8888-8888-888888888888",
+    id: "88888888-8888-4888-8888-888888888888",
     email: "user8@example.com",
     password: "##user8",
     name: "技術 伝道師",
@@ -154,7 +157,7 @@ const testUsers = [
     slackId: "@user8",
   },
   {
-    id: "99999999-9999-9999-9999-999999999999",
+    id: "99999999-9999-4999-8999-999999999999",
     email: "user9@example.com",
     password: "##user9",
     name: "運用 監視子",
@@ -162,7 +165,7 @@ const testUsers = [
     slackId: "@user9",
   },
   {
-    id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
     email: "user10@example.com",
     password: "##user10",
     name: "学習 熱心男",

--- a/src/app/(private)/learning-logs/_components/LearningLogPage.tsx
+++ b/src/app/(private)/learning-logs/_components/LearningLogPage.tsx
@@ -108,7 +108,7 @@ export const LearningLogPage: React.FC<Props> = ({ batch }) => {
   }, [pageInfo.total, pageInfo.page, pageInfo.perPage]);
 
   return (
-    <div className="4xl:px-0 mx-auto my-4 w-full max-w-4xl space-y-4 px-4">
+    <div className="mx-auto my-4 w-full max-w-4xl space-y-4 px-4 2xl:px-0">
       <div className="flex flex-col items-center gap-y-0.5">
         {/* サブタイトルも設定する関係で PageTitleコンポーネントを使用しない */}
         <h1 className="text-3xl font-bold">学習ログ一覧</h1>

--- a/src/app/(private)/learning-logs/_components/LearningLogPage.tsx
+++ b/src/app/(private)/learning-logs/_components/LearningLogPage.tsx
@@ -34,7 +34,7 @@ type Props = {
   batch: LearningLogsBatch;
 };
 
-export const LearningLogView: React.FC<Props> = ({ batch }) => {
+export const LearningLogPage: React.FC<Props> = ({ batch }) => {
   const router = useRouter();
   const [logs, setLogs] = useState<LearningLog[]>(batch.learningLogs);
   const [pageInfo, setPageInfo] = useState<PageInfo>(batch.pageInfo);
@@ -108,7 +108,7 @@ export const LearningLogView: React.FC<Props> = ({ batch }) => {
   }, [pageInfo.total, pageInfo.page, pageInfo.perPage]);
 
   return (
-    <div className="mx-auto w-full max-w-5xl px-4 py-8">
+    <div className="4xl:px-0 mx-auto my-4 w-full max-w-4xl space-y-4 px-4">
       <div className="flex flex-col items-center gap-y-0.5">
         {/* サブタイトルも設定する関係で PageTitleコンポーネントを使用しない */}
         <h1 className="text-3xl font-bold">学習ログ一覧</h1>

--- a/src/app/(private)/learning-logs/_components/LearningLogView.tsx
+++ b/src/app/(private)/learning-logs/_components/LearningLogView.tsx
@@ -108,7 +108,7 @@ export const LearningLogView: React.FC<Props> = ({ batch }) => {
   }, [pageInfo.total, pageInfo.page, pageInfo.perPage]);
 
   return (
-    <>
+    <div className="mx-auto w-full max-w-5xl px-4 py-8">
       <div className="flex flex-col items-center gap-y-0.5">
         {/* サブタイトルも設定する関係で PageTitleコンポーネントを使用しない */}
         <h1 className="text-3xl font-bold">学習ログ一覧</h1>
@@ -142,6 +142,6 @@ export const LearningLogView: React.FC<Props> = ({ batch }) => {
         onPageChange={onPageChange}
         disabled={isPending}
       />
-    </>
+    </div>
   );
 };

--- a/src/app/(private)/learning-logs/_mock/getMockLearningLogsResponse.ts
+++ b/src/app/(private)/learning-logs/_mock/getMockLearningLogsResponse.ts
@@ -8,11 +8,15 @@ export const getMockLearningLogsResponse = (
 ): LearningLogsBatch => {
   // ソート処理 [primary sort key] startedAt、[secondary sort key] createdAt
   const sorted = [...learningLogsMock].sort((a, b) => {
+    // startedAt が「未設定」のときは常に先頭に配置する（暗黙に入力を促す）
+    const fallbackTime =
+      sortOrder === "desc"
+        ? Number.POSITIVE_INFINITY
+        : Number.NEGATIVE_INFINITY;
     // prettier-ignore
-    const aTime = a.startedAt ? a.startedAt.getTime() : Number.POSITIVE_INFINITY;
+    const aTime = a.startedAt ? a.startedAt.getTime() : fallbackTime;
     // prettier-ignore
-    const bTime = b.startedAt ? b.startedAt.getTime() : Number.POSITIVE_INFINITY;
-
+    const bTime = b.startedAt ? b.startedAt.getTime() : fallbackTime;
     if (aTime !== bTime)
       return sortOrder === "desc" ? bTime - aTime : aTime - bTime;
 

--- a/src/app/(private)/learning-logs/page.tsx
+++ b/src/app/(private)/learning-logs/page.tsx
@@ -2,7 +2,7 @@ import { authenticateAppUser } from "@/app/_libs/authenticateUser";
 
 // UIコンポーネント・アイコン
 import { ErrorPage } from "@/app/_components/ErrorPage";
-import { LearningLogView } from "./_components/LearningLogView";
+import { LearningLogPage } from "./_components/LearningLogPage";
 
 // 型定義・バリデーションスキーマ
 import { learningLogSearchParamsSchema } from "@/app/_types/LearningLog";
@@ -35,7 +35,7 @@ const Page: React.FC<Props> = async ({ searchParams }) => {
     // TODO: Implement learning log fetch in another branch
     const firstBatch = getMockLearningLogsResponse(page, per, order);
 
-    return <LearningLogView batch={firstBatch} />;
+    return <LearningLogPage batch={firstBatch} />;
   } catch (e) {
     dumpError(e, "学習ログ");
     const errMsg =

--- a/src/app/_libs/errors.ts
+++ b/src/app/_libs/errors.ts
@@ -37,6 +37,27 @@ export class AppUserNotFoundError extends Error {
 }
 
 /**
+ * 学習ログが見つからなかった場合のエラー
+ */
+export class LearningLogNotFoundError extends Error {
+  readonly learningLogId: string;
+  readonly timestamp: Date;
+
+  constructor(
+    learningLogId: string,
+    message = "Learning log not found in application database",
+  ) {
+    super(message);
+    this.name = "LearningLogNotFoundError";
+    this.learningLogId = learningLogId;
+    this.timestamp = new Date();
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LearningLogNotFoundError);
+    }
+  }
+}
+
+/**
  * ユーザーが必要な権限を持たないために操作が拒否された場合のエラー
  */
 export class UserPermissionDeniedError extends Error {
@@ -72,3 +93,7 @@ export class UserPermissionDeniedError extends Error {
     }
   }
 }
+
+export const isPrismaNotFoundError = (error: unknown): boolean => {
+  return error instanceof Error && "code" in error && error.code === "P2025";
+};

--- a/src/app/_libs/errors.ts
+++ b/src/app/_libs/errors.ts
@@ -93,7 +93,3 @@ export class UserPermissionDeniedError extends Error {
     }
   }
 }
-
-export const isPrismaNotFoundError = (error: unknown): boolean => {
-  return error instanceof Error && "code" in error && error.code === "P2025";
-};

--- a/src/app/_services/learningLogService.ts
+++ b/src/app/_services/learningLogService.ts
@@ -1,5 +1,7 @@
-import { LearningLog as PrismaLearningLog } from "@prisma/client";
-import { Prisma as PRS } from "@prisma/client";
+import {
+  Prisma as PRS,
+  LearningLog as PrismaLearningLog,
+} from "@prisma/client";
 import {
   LearningLogNotFoundError,
   UserPermissionDeniedError,

--- a/src/app/_services/learningLogService.ts
+++ b/src/app/_services/learningLogService.ts
@@ -1,0 +1,204 @@
+import { LearningLog as PrismaLearningLog } from "@prisma/client";
+import { Prisma as PRS } from "@prisma/client";
+import {
+  LearningLogNotFoundError,
+  UserPermissionDeniedError,
+} from "@/app/_libs/errors";
+import {
+  SortOrder,
+  LearningLog,
+  LearningLogsBatch,
+  LearningLogUpdateRequest,
+  LearningLogInsertRequest,
+  learningLogsBatchSchema,
+} from "@/app/_types/LearningLog";
+import { DbClient } from "@/app/_types/Services";
+
+/**
+ * LearningLog のクエリの結果型を取得するためのHelper型
+ * @note include と select を同時に指定することはできないので注意！
+ * @template T extends PRS.LearningLogInclude - includeオプションの型
+ * @template U extends PRS.LearningLogSelect - selectオプションの型
+ */
+export type LearningLogReturnType<
+  T extends PRS.LearningLogInclude,
+  U extends PRS.LearningLogSelect,
+> = {
+  include?: T;
+  select?: U;
+};
+
+/**
+ * PrismaのLearningLogモデルからLearningLog型への変換
+ * （createdAt を除去して、特定属性を null から undefined に変換）
+ */
+const toAppLearningLog = (
+  prismaLearningLog: PrismaLearningLog,
+): LearningLog => {
+  const { createdAt, taskId, startedAt, endedAt, ...rest } = prismaLearningLog;
+  return {
+    ...rest,
+    taskId: taskId ?? undefined,
+    startedAt: startedAt ?? undefined,
+    endedAt: endedAt ?? undefined,
+  };
+};
+
+/**
+ * LearningLogのCRUD操作を担当するサービスクラス
+ *
+ * 基本的に、このサービスクラスの各メソッドでは認証や認可の検証処理はしないので、
+ * サービスクラスの利用側で、認証・認可を確認して利用してください。
+ * 各種処理の失敗は、エラーによって通知する設計としています。
+ */
+class LearningLogService {
+  private readonly prisma: DbClient;
+
+  public constructor(prisma: DbClient) {
+    this.prisma = prisma;
+  }
+
+  public async count(): Promise<number> {
+    return await this.prisma.learningLog.count();
+  }
+
+  /**
+   * LogIdをキーとした学習ログ情報の取得（存在しなければ null を返す）
+   * @template T extends PRS.LearningLogInclude - includeオプションの型
+   * @template U extends PRS.LearningLogSelect - selectオプションの型
+   * @param logId - 取得する学習ログのID
+   * @param options - Prismaクエリオプション（include、selectなど）
+   */
+  public async tryGetById<
+    T extends PRS.LearningLogInclude,
+    U extends PRS.LearningLogSelect,
+  >(
+    logId: string,
+    options?: LearningLogReturnType<T, U>,
+  ): Promise<PRS.LearningLogGetPayload<{ include: T; select: U }> | null> {
+    return (await this.prisma.learningLog.findUnique({
+      where: { id: logId },
+      ...options,
+    })) as PRS.LearningLogGetPayload<{ include: T; select: U }> | null;
+  }
+
+  /**
+   * 所有権チェック付きでLogIdによる学習ログ情報の取得（該当なしや権限なしの場合は例外をスロー）
+   * @param userId - 所有権を確認するユーザーID（nullの場合は所有権チェックなし）
+   * @param logId - 取得する学習ログのID
+   * @param options - Prismaクエリオプション（include、selectなど）
+   * @throws {LearningLogNotFoundError} 指定されたIDの学習ログが存在しない場合
+   * @throws {UserPermissionDeniedError} 指定されたユーザーが学習ログの所有者ではない場合
+   */
+  public async getByIdWithOwnershipCheck<
+    T extends PRS.LearningLogInclude,
+    U extends PRS.LearningLogSelect,
+  >(
+    userId: string | null,
+    logId: string,
+    options?: LearningLogReturnType<T, U>,
+  ): Promise<PRS.LearningLogGetPayload<{ include: T; select: U }>> {
+    const learningLog = await this.tryGetById(logId, options);
+    // 学習ログの存在チェック
+    if (!learningLog) throw new LearningLogNotFoundError(logId);
+    // 学習ログの所有権チェック
+    if (userId && learningLog.userId !== userId) {
+      throw new UserPermissionDeniedError({
+        userId,
+        actualRole: "Unknown",
+        message: `User ${userId} does not own LearningLog ${logId}`,
+      });
+    }
+    return learningLog;
+  }
+
+  // 新規作成 [Create]
+  public async create(
+    userId: string,
+    data: LearningLogInsertRequest,
+  ): Promise<LearningLog> {
+    const createdLearningLog = await this.prisma.learningLog.create({
+      data: {
+        ...data,
+        taskId: data.taskId ?? null,
+        startedAt: data.startedAt ?? null,
+        endedAt: data.endedAt ?? null,
+        userId,
+      },
+    });
+    return toAppLearningLog(createdLearningLog);
+  }
+
+  // 更新 [Update]
+  public async update(
+    userId: string | null,
+    logId: string,
+    data: LearningLogUpdateRequest,
+  ): Promise<LearningLog> {
+    await this.getByIdWithOwnershipCheck(userId, logId);
+    const updatedLearningLog = await this.prisma.learningLog.update({
+      where: { id: logId },
+      data: {
+        ...data,
+        taskId: data.taskId ?? null,
+        startedAt: data.startedAt ?? null,
+        endedAt: data.endedAt ?? null,
+      },
+    });
+    return toAppLearningLog(updatedLearningLog);
+  }
+
+  // 削除 [Delete]
+  public async delete(userId: string | null, logId: string): Promise<void> {
+    await this.getByIdWithOwnershipCheck(userId, logId);
+    await this.prisma.learningLog.delete({ where: { id: logId } });
+  }
+
+  /**
+   * ユーザーの学習ログをページネーション付きで取得
+   * @param userId - 対象とするユーザーのID。呼び出し元で存在を要保証
+   * @param page - 何ページ目か（Default:1）。呼び出し元で1以上を要保証
+   * @param perPage - 1ページに何件か（Default:5）。呼び出し元で1以上を要保証
+   * @param order - ソート順序（Default: "desc" 新しい順）
+   * @returns 学習ログのバッチのPromise
+   */
+  public async getPaginatedBatch(
+    userId: string,
+    page: number = 1,
+    perPage: number = 5,
+    order: SortOrder = "desc",
+  ): Promise<LearningLogsBatch> {
+    // ソート設定
+    // プライマリソート: startedAt（未設定= null は常に先頭に配置（暗黙に入力を促す）
+    // セカンダリソート: createdAt、タイブレーカ: id
+    const orderBy: PRS.LearningLogOrderByWithRelationInput[] = [
+      { startedAt: { sort: order, nulls: "first" } },
+      { createdAt: order },
+      { id: order },
+    ];
+
+    // データ取得とカウントを並行実行
+    const [rawLearningLogs, total] = await Promise.all([
+      this.prisma.learningLog.findMany({
+        where: { userId },
+        orderBy,
+        skip: (page - 1) * perPage,
+        take: perPage,
+      }),
+      this.prisma.learningLog.count({
+        where: { userId },
+      }),
+    ]);
+
+    // createdAt プロパティを除去、型のマッピング（null → undefined）
+    const learningLogs = rawLearningLogs.map(toAppLearningLog);
+    const batch: LearningLogsBatch = learningLogsBatchSchema.parse({
+      learningLogs,
+      pageInfo: { page, perPage, total },
+      sortOrder: order,
+    });
+    return batch;
+  }
+}
+
+export { LearningLogService };

--- a/src/app/_types/CommonSchemas.ts
+++ b/src/app/_types/CommonSchemas.ts
@@ -53,11 +53,8 @@ export const profileImageKeySchema = z
   .transform((val) => (val.trim() === "" ? undefined : val))
   .optional();
 
-// prettier-ignore
-export const isUUID = (value: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
-
-export const uuidSchema = z.string().refine(isUUID, {
-  message: "Invalid UUID format.",
+export const uuidSchema = z.uuidv4({
+  error: "UUIDの形式が正しくありません。",
 });
 
 // 学習ログ（LearningLog）関連の zod スキーマ

--- a/src/app/_types/LearningLog.ts
+++ b/src/app/_types/LearningLog.ts
@@ -11,7 +11,7 @@ import {
 export const learningLogSchema = z.object({
   id: uuidSchema,
   userId: uuidSchema,
-  taskId: uuidSchema,
+  taskId: uuidSchema.optional(), // タスクに紐づく場合は存在する
   title: learningLogTitleSchema,
   description: learningLogDescriptionSchema, // 学習内容の詳細
   reflections: learningLogReflectionsSchema, // 振り返り・課題や反省・改善点・学び
@@ -29,7 +29,8 @@ export const pageInfoSchema = z.object({
   total: z.number().int().min(0), // 総件数
 });
 
-const sortOrderSchema = z.enum(["asc", "desc"]);
+export const sortOrderSchema = z.enum(["asc", "desc"]);
+export type SortOrder = z.infer<typeof sortOrderSchema>;
 
 export type PageInfo = z.infer<typeof pageInfoSchema>;
 
@@ -61,4 +62,32 @@ export const learningLogSearchParamsSchema = z.object({
 
 export type LearningLogSearchParams = z.infer<
   typeof learningLogSearchParamsSchema
+>;
+
+// 挿入・更新の共通入力フィールド（id, userId以外）
+const learningLogUpsertBaseSchema = z.object({
+  taskId: uuidSchema.optional(),
+  title: learningLogTitleSchema,
+  description: learningLogDescriptionSchema,
+  reflections: learningLogReflectionsSchema,
+  spentMinutes: learningLogSpentMinutesSchema,
+  startedAt: learningLogDateSchema,
+  endedAt: learningLogDateSchema,
+});
+
+// 挿入用スキーマ
+export const learningLogInsertRequestSchema = learningLogUpsertBaseSchema;
+
+// 更新用スキーマ（入力フィールド + id）
+export const learningLogUpdateRequestSchema =
+  learningLogUpsertBaseSchema.extend({
+    id: uuidSchema,
+  });
+
+// 型定義
+export type LearningLogInsertRequest = z.infer<
+  typeof learningLogInsertRequestSchema
+>;
+export type LearningLogUpdateRequest = z.infer<
+  typeof learningLogUpdateRequestSchema
 >;

--- a/src/app/_types/Services.ts
+++ b/src/app/_types/Services.ts
@@ -1,0 +1,3 @@
+import { Prisma, PrismaClient } from "@prisma/client";
+
+export type DbClient = PrismaClient | Prisma.TransactionClient;

--- a/tests/LearningLogService/create.spec.ts
+++ b/tests/LearningLogService/create.spec.ts
@@ -12,9 +12,7 @@ import { v4 as uuid } from "uuid";
 describe("LearningLogService create", () => {
   test("LearningLogInsertRequestデータのzod検証", () => {
     for (const [index, request] of mockLearningLogs.entries()) {
-      expect(() => learningLogInsertRequestSchema.parse(request)).not.toThrow(
-        `Index ${index} should be valid LearningLogInsertRequest`,
-      );
+      expect(() => learningLogInsertRequestSchema.parse(request)).not.toThrow();
     }
   });
 

--- a/tests/LearningLogService/create.spec.ts
+++ b/tests/LearningLogService/create.spec.ts
@@ -1,0 +1,161 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import { UserService } from "@/app/_services/userService";
+import {
+  mockLearningLogs,
+  mockLearningLogWithOptionalFields,
+} from "./helpers/common-mock-data";
+import { learningLogInsertRequestSchema } from "@/app/_types/LearningLog";
+import { v4 as uuid } from "uuid";
+
+describe("LearningLogService create", () => {
+  test("LearningLogInsertRequestデータのzod検証", () => {
+    for (const [index, request] of mockLearningLogs.entries()) {
+      expect(() => learningLogInsertRequestSchema.parse(request)).not.toThrow(
+        `Index ${index} should be valid LearningLogInsertRequest`,
+      );
+    }
+  });
+
+  test("count - 学習ログ数を正しく取得できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      const learningLogService = new LearningLogService(tx);
+      const initialCount = await learningLogService.count();
+
+      // ユーザー作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // 学習ログ作成前後でカウントが増加（+1）することを確認
+      const logData = mockLearningLogs[0];
+      await learningLogService.create(userId, logData);
+
+      const afterCount = await learningLogService.count();
+      expect(afterCount).toBe(initialCount + 1);
+    });
+  });
+
+  test("学習ログを正常に「新規作成」できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      // (1) ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // (2) ユーザ作成の確認
+      const createdUser = await userService.getById(userId);
+      expect(createdUser.name).toBe(userName);
+
+      // (3) 学習ログサービスの初期化
+      const learningLogService = new LearningLogService(tx);
+      const initialCount = await learningLogService.count();
+
+      // (4) 学習ログの新規作成
+      const logData = mockLearningLogs[0];
+      const createdLog = await learningLogService.create(userId, logData);
+
+      // (5) 作成結果の検証
+      expect(createdLog).toBeDefined();
+      expect(createdLog.id).toBeDefined();
+      expect(createdLog.userId).toBe(userId);
+      expect(createdLog.title).toBe(logData.title);
+      expect(createdLog.description).toBe(logData.description);
+      expect(createdLog.reflections).toBe(logData.reflections);
+      expect(createdLog.spentMinutes).toBe(logData.spentMinutes);
+      expect(createdLog.startedAt).toEqual(logData.startedAt);
+      expect(createdLog.endedAt).toEqual(logData.endedAt);
+
+      // (6) カウント増加の確認
+      expect(await learningLogService.count()).toBe(initialCount + 1);
+    });
+  });
+
+  test("型変換テスト - null値がundefinedに変換される", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザー作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // taskId, startedAt, endedAt が undefined の学習ログを作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLogWithOptionalFields,
+      );
+
+      // 作成されたログの型を確認
+      expect(createdLog.taskId).toBeUndefined(); // nullからundefinedに変換されている
+      expect(createdLog.startedAt).toBeUndefined(); // nullからundefinedに変換されている
+      expect(createdLog.endedAt).toBeUndefined(); // nullからundefinedに変換されている
+
+      // 他のフィールドは正常に設定されている
+      expect(createdLog.title).toBe(mockLearningLogWithOptionalFields.title);
+      expect(createdLog.spentMinutes).toBe(
+        mockLearningLogWithOptionalFields.spentMinutes,
+      );
+    });
+  });
+
+  test("型変換テスト - createdAtフィールドが除去される", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザー作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const logData = mockLearningLogs[0];
+      const createdLog = await learningLogService.create(userId, logData);
+
+      // createdAtプロパティが除去されていることを確認
+      expect("createdAt" in createdLog).toBe(false);
+
+      // 他の必要なプロパティは存在していることを確認
+      expect(createdLog.id).toBeDefined();
+      expect(createdLog.userId).toBeDefined();
+      expect(createdLog.title).toBeDefined();
+    });
+  });
+
+  test("複数の学習ログを作成する総合テスト", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      const learningLogService = new LearningLogService(tx);
+      const initialCount = await learningLogService.count();
+
+      // 複数の学習ログを作成
+      const createdLogs = [];
+      for (const logData of mockLearningLogs) {
+        const createdLog = await learningLogService.create(userId, logData);
+        createdLogs.push(createdLog);
+      }
+
+      // 全て作成されたことを確認
+      expect(await learningLogService.count()).toBe(
+        initialCount + mockLearningLogs.length,
+      );
+
+      // 各ログが正しく取得できることを確認
+      for (const [index, createdLog] of createdLogs.entries()) {
+        const retrievedLog = await learningLogService.getByIdWithOwnershipCheck(
+          userId,
+          createdLog.id,
+        );
+        expect(retrievedLog.title).toBe(mockLearningLogs[index].title);
+      }
+    });
+  });
+});

--- a/tests/LearningLogService/delete.spec.ts
+++ b/tests/LearningLogService/delete.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import { UserService } from "@/app/_services/userService";
+import { mockLearningLog } from "./helpers/common-mock-data";
+import {
+  LearningLogNotFoundError,
+  UserPermissionDeniedError,
+} from "@/app/_libs/errors";
+import { v4 as uuid } from "uuid";
+
+describe("LearningLogService delete", () => {
+  test("他のユーザーの学習ログ削除でUserPermissionDeniedErrorが発生する", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザA作成
+      const userAId = uuid();
+      const userAName = "品質 管理代";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userAId, userAName);
+
+      // ユーザB作成
+      const userBId = uuid();
+      const userBName = "不具合 退治丸";
+      await userService.createAsStudent(userBId, userBName);
+
+      // ユーザAの学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userAId,
+        mockLearningLog,
+      );
+
+      // ユーザBがユーザAの学習ログを削除しようとする
+      await expect(
+        learningLogService.delete(userBId, createdLog.id),
+      ).rejects.toThrow(UserPermissionDeniedError);
+    });
+  });
+
+  test("学習ログを正常に削除できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      const initialCount = await learningLogService.count();
+
+      // 削除実行（所有者として）
+      await learningLogService.delete(userId, createdLog.id);
+
+      // 削除確認
+      expect(await learningLogService.count()).toBe(initialCount - 1);
+
+      // 取得できないことの確認
+      await expect(
+        learningLogService.getByIdWithOwnershipCheck(null, createdLog.id),
+      ).rejects.toThrow(LearningLogNotFoundError);
+    });
+  });
+
+  test("存在しない学習ログの削除でLearningLogNotFoundErrorが発生する", async () => {
+    await runInRollbackTx(async (tx) => {
+      const learningLogService = new LearningLogService(tx);
+      const nonExistentId = uuid();
+
+      await expect(
+        learningLogService.delete(null, nonExistentId),
+      ).rejects.toThrow(LearningLogNotFoundError);
+    });
+  });
+
+  test("userId=nullで所有権チェックをスキップする", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      const initialCount = await learningLogService.count();
+
+      // userId=nullで削除（所有権チェックをスキップ）
+      await learningLogService.delete(null, createdLog.id);
+
+      // 削除確認
+      expect(await learningLogService.count()).toBe(initialCount - 1);
+
+      // 取得できないことの確認
+      await expect(
+        learningLogService.getByIdWithOwnershipCheck(null, createdLog.id),
+      ).rejects.toThrow(LearningLogNotFoundError);
+    });
+  });
+});

--- a/tests/LearningLogService/getByIdWithOwnershipCheck.spec.ts
+++ b/tests/LearningLogService/getByIdWithOwnershipCheck.spec.ts
@@ -146,9 +146,12 @@ describe("LearningLogService getByIdWithOwnershipCheck", () => {
       expect(selectedLog.userId).toBe(userId);
 
       // (5) 選択していないフィールドは undefined であることを確認
-      expect(selectedLog.description).toBeUndefined();
-      expect(selectedLog.reflections).toBeUndefined();
-      expect(selectedLog.spentMinutes).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- selectで除外されたフィールドの実行時チェックのため
+      expect((selectedLog as any).description).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- selectで除外されたフィールドの実行時チェックのため
+      expect((selectedLog as any).reflections).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- selectで除外されたフィールドの実行時チェックのため
+      expect((selectedLog as any).spentMinutes).toBeUndefined();
     });
   });
 
@@ -211,10 +214,15 @@ describe("LearningLogService getByIdWithOwnershipCheck", () => {
       expect(selectedLog.title).toBe(mockLearningLog.title);
 
       // (5) 選択していないフィールドは undefined であることを確認
-      expect(selectedLog.userId).toBeUndefined();
-      expect(selectedLog.description).toBeUndefined();
-      expect(selectedLog.reflections).toBeUndefined();
-      expect(selectedLog.spentMinutes).toBeUndefined();
+      //     - selectで除外されたフィールドの実行時チェックのため意図的に any 型にキャスト
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((selectedLog as any).userId).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((selectedLog as any).description).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((selectedLog as any).reflections).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((selectedLog as any).spentMinutes).toBeUndefined();
     });
   });
 
@@ -240,16 +248,12 @@ describe("LearningLogService getByIdWithOwnershipCheck", () => {
 
       // (4) ユーザBがselectでuserIdを除外してアクセス → UserPermissionDeniedErrorがスロー
       await expect(
-        learningLogService.getByIdWithOwnershipCheck(
-          userBId,
-          createdLog.id,
-          {
-            select: {
-              id: true,
-              title: true,
-            },
+        learningLogService.getByIdWithOwnershipCheck(userBId, createdLog.id, {
+          select: {
+            id: true,
+            title: true,
           },
-        ),
+        }),
       ).rejects.toThrow(UserPermissionDeniedError);
     });
   });

--- a/tests/LearningLogService/getByIdWithOwnershipCheck.spec.ts
+++ b/tests/LearningLogService/getByIdWithOwnershipCheck.spec.ts
@@ -1,0 +1,181 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import { UserService } from "@/app/_services/userService";
+import {
+  mockLearningLog,
+  mockLearningLogWithOptionalFields,
+} from "./helpers/common-mock-data";
+import {
+  LearningLogNotFoundError,
+  UserPermissionDeniedError,
+} from "@/app/_libs/errors";
+import { v4 as uuid } from "uuid";
+
+describe("LearningLogService getByIdWithOwnershipCheck", () => {
+  test("他のユーザーの学習ログアクセスでUserPermissionDeniedErrorが発生する", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザA作成
+      const userAId = uuid();
+      const userAName = "品質 管理代";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userAId, userAName);
+
+      // ユーザB作成
+      const userBId = uuid();
+      const userBName = "不具合 退治丸";
+      await userService.createAsStudent(userBId, userBName);
+
+      // ユーザAの学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userAId,
+        mockLearningLog,
+      );
+
+      // ユーザB が ユーザA の学習ログにアクセス → UserPermissionDeniedError がスロー
+      await expect(
+        learningLogService.getByIdWithOwnershipCheck(userBId, createdLog.id),
+      ).rejects.toThrow(UserPermissionDeniedError);
+    });
+  });
+
+  test("userId=nullで所有権チェックをスキップする", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      // userId=nullで取得（所有権チェックをスキップ）
+      const retrievedLog = await learningLogService.getByIdWithOwnershipCheck(
+        null,
+        createdLog.id,
+      );
+
+      // 取得結果の検証
+      expect(retrievedLog).toBeDefined();
+      expect(retrievedLog.id).toBe(createdLog.id);
+      expect(retrievedLog.userId).toBe(userId);
+      expect(retrievedLog.title).toBe(mockLearningLog.title);
+    });
+  });
+
+  test("所有権を確認して学習ログを正常に取得できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      // (1) ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // (2) 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      // (3) 正しい所有者を指定して取得
+      const retrievedLog = await learningLogService.getByIdWithOwnershipCheck(
+        userId,
+        createdLog.id,
+      );
+
+      // (4) 取得結果の検証
+      expect(retrievedLog).toBeDefined();
+      expect(retrievedLog.id).toBe(createdLog.id);
+      expect(retrievedLog.userId).toBe(userId);
+      expect(retrievedLog.title).toBe(mockLearningLog.title);
+      expect(retrievedLog.description).toBe(mockLearningLog.description);
+      expect(retrievedLog.reflections).toBe(mockLearningLog.reflections);
+      expect(retrievedLog.spentMinutes).toBe(mockLearningLog.spentMinutes);
+    });
+  });
+
+  test("存在しない学習ログでLearningLogNotFoundErrorが発生する", async () => {
+    await runInRollbackTx(async (tx) => {
+      const learningLogService = new LearningLogService(tx);
+      const nonExistentId = uuid(); // 存在しない学習ログID
+
+      await expect(
+        learningLogService.getByIdWithOwnershipCheck(null, nonExistentId),
+      ).rejects.toThrow(LearningLogNotFoundError);
+    });
+  });
+
+  test("selectオプションで指定フィールドのみ取得", async () => {
+    await runInRollbackTx(async (tx) => {
+      // (1) ユーザー作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // (2) 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      // (3) selectオプションでtitleとuserIdのみ取得
+      const selectedLog = await learningLogService.getByIdWithOwnershipCheck(
+        userId,
+        createdLog.id,
+        {
+          select: {
+            id: true,
+            title: true,
+            userId: true,
+          },
+        },
+      );
+
+      // (4) 指定したフィールドが存在することを確認
+      expect(selectedLog.id).toBe(createdLog.id);
+      expect(selectedLog.title).toBe(mockLearningLog.title);
+      expect(selectedLog.userId).toBe(userId);
+
+      // (5) 選択していないフィールドは undefined であることを確認
+      expect(selectedLog.description).toBeUndefined();
+      expect(selectedLog.reflections).toBeUndefined();
+      expect(selectedLog.spentMinutes).toBeUndefined();
+    });
+  });
+
+  test("型変換テスト - null値の扱い", async () => {
+    await runInRollbackTx(async (tx) => {
+      // (1) ユーザー作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // (2) taskId, startedAt, endedAt が undefined の学習ログを作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLogWithOptionalFields,
+      );
+
+      // (3) getByIdWithOwnershipCheckでも同様の変換がされることを確認
+      const retrievedLog = await learningLogService.getByIdWithOwnershipCheck(
+        userId,
+        createdLog.id,
+      );
+
+      expect(retrievedLog.taskId).toBeNull(); // Prisma の生の型なので null
+      expect(retrievedLog.startedAt).toBeNull();
+      expect(retrievedLog.endedAt).toBeNull();
+    });
+  });
+});

--- a/tests/LearningLogService/getPaginatedBatch-basic.spec.ts
+++ b/tests/LearningLogService/getPaginatedBatch-basic.spec.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import { createDummyLearningLogData } from "./helpers/test-data-generator";
+import { createTestUser, createBulkLearningLogs } from "./helpers/test-setup";
+
+describe("LearningLogService.getPaginatedBatch - 基本的なページネーション", () => {
+  const dummyLogs = createDummyLearningLogData();
+
+  test("デフォルトパラメータ（1ページ目、5件、降順）", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      await createBulkLearningLogs(tx, userId, dummyLogs);
+
+      const learningLogService = new LearningLogService(tx);
+      const batch = await learningLogService.getPaginatedBatch(userId);
+
+      // 基本検証
+      expect(batch.learningLogs).toHaveLength(5);
+      expect(batch.pageInfo.page).toBe(1);
+      expect(batch.pageInfo.perPage).toBe(5);
+      expect(batch.pageInfo.total).toBe(99);
+      expect(batch.sortOrder).toBe("desc");
+
+      // 降順の場合、最新（#99）から順番に表示されることを確認
+      expect(batch.learningLogs[0].title).toBe("#99");
+      expect(batch.learningLogs[1].title).toBe("#98");
+      expect(batch.learningLogs[2].title).toBe("#97");
+      expect(batch.learningLogs[3].title).toBe("#96");
+      expect(batch.learningLogs[4].title).toBe("#95");
+    });
+  });
+
+  test("2ページ目を取得", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      await createBulkLearningLogs(tx, userId, dummyLogs);
+
+      const learningLogService = new LearningLogService(tx);
+      const batch = await learningLogService.getPaginatedBatch(
+        userId,
+        2,
+        5,
+        "desc",
+      );
+
+      // 基本検証
+      expect(batch.learningLogs).toHaveLength(5);
+      expect(batch.pageInfo.page).toBe(2);
+      expect(batch.pageInfo.perPage).toBe(5);
+      expect(batch.pageInfo.total).toBe(99);
+
+      // 2ページ目の内容を確認（降順）
+      expect(batch.learningLogs[0].title).toBe("#94");
+      expect(batch.learningLogs[1].title).toBe("#93");
+      expect(batch.learningLogs[2].title).toBe("#92");
+      expect(batch.learningLogs[3].title).toBe("#91");
+      expect(batch.learningLogs[4].title).toBe("#90");
+    });
+  });
+
+  test("1ページあたりの件数を変更", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      // 15件のダミーデータを作成
+      await createBulkLearningLogs(tx, userId, dummyLogs.slice(0, 15));
+
+      const learningLogService = new LearningLogService(tx);
+      // 1ページ10件で取得
+      const batch = await learningLogService.getPaginatedBatch(
+        userId,
+        1,
+        10,
+        "desc",
+      );
+
+      expect(batch.learningLogs).toHaveLength(10);
+      expect(batch.pageInfo.perPage).toBe(10);
+      expect(batch.pageInfo.total).toBe(15);
+    });
+  });
+
+  test("最後のページ（端数）", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      await createBulkLearningLogs(tx, userId, dummyLogs);
+
+      const learningLogService = new LearningLogService(tx);
+      // 最後のページ（20ページ目、1ページ5件の場合）
+      const lastPage = Math.ceil(99 / 5); // 20ページ
+      const batch = await learningLogService.getPaginatedBatch(
+        userId,
+        lastPage,
+        5,
+        "desc",
+      );
+
+      // 最後のページは4件のみ
+      expect(batch.learningLogs).toHaveLength(4);
+      expect(batch.pageInfo.page).toBe(20);
+      expect(batch.pageInfo.total).toBe(99);
+
+      // 最後のページの内容を確認（降順なので #04, #03, #02, #01）
+      expect(batch.learningLogs[0].title).toBe("#04");
+      expect(batch.learningLogs[1].title).toBe("#03");
+      expect(batch.learningLogs[2].title).toBe("#02");
+      expect(batch.learningLogs[3].title).toBe("#01");
+    });
+  });
+});

--- a/tests/LearningLogService/getPaginatedBatch-edge-cases.spec.ts
+++ b/tests/LearningLogService/getPaginatedBatch-edge-cases.spec.ts
@@ -1,0 +1,166 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import { createDummyLearningLogData } from "./helpers/test-data-generator";
+import {
+  createTestUser,
+  setupMultipleUsersWithLogs,
+  createBulkLearningLogs,
+} from "./helpers/test-setup";
+
+describe("LearningLogService.getPaginatedBatch - エッジケース", () => {
+  const dummyLogs = createDummyLearningLogData();
+
+  test("データが存在しない場合", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+
+      const learningLogService = new LearningLogService(tx);
+      // データを作成せずに取得
+      const batch = await learningLogService.getPaginatedBatch(userId);
+
+      expect(batch.learningLogs).toHaveLength(0);
+      expect(batch.pageInfo.page).toBe(1);
+      expect(batch.pageInfo.perPage).toBe(5);
+      expect(batch.pageInfo.total).toBe(0);
+    });
+  });
+
+  test("存在しないページ", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      // 5件のダミーデータを作成
+      await createBulkLearningLogs(tx, userId, dummyLogs.slice(0, 5));
+
+      const learningLogService = new LearningLogService(tx);
+      // 存在しない3ページ目を取得
+      const batch = await learningLogService.getPaginatedBatch(
+        userId,
+        3,
+        5,
+        "desc",
+      );
+
+      expect(batch.learningLogs).toHaveLength(0);
+      expect(batch.pageInfo.page).toBe(3);
+      expect(batch.pageInfo.perPage).toBe(5);
+      expect(batch.pageInfo.total).toBe(5);
+    });
+  });
+
+  test("異なるユーザーのデータは取得されない", async () => {
+    await runInRollbackTx(async (tx) => {
+      // 2人のユーザーを作成し、それぞれに異なる数の学習ログを作成
+      const users = await setupMultipleUsersWithLogs(
+        tx,
+        [
+          { userName: "不具合 退治丸", logCount: 10, startIndex: 0 },
+          { userName: "品質 管理代", logCount: 5, startIndex: 10 },
+        ],
+        dummyLogs,
+      );
+
+      const learningLogService = new LearningLogService(tx);
+
+      // ユーザー1のデータのみ取得されることを確認
+      const batch1 = await learningLogService.getPaginatedBatch(users[0].id);
+      expect(batch1.learningLogs).toHaveLength(5); // 1ページ5件
+      expect(batch1.pageInfo.total).toBe(10);
+
+      // ユーザー2のデータのみ取得されることを確認
+      const batch2 = await learningLogService.getPaginatedBatch(users[1].id);
+      expect(batch2.learningLogs).toHaveLength(5);
+      expect(batch2.pageInfo.total).toBe(5);
+    });
+  });
+
+  test("存在しないユーザーIDでの呼び出し", async () => {
+    await runInRollbackTx(async (tx) => {
+      const learningLogService = new LearningLogService(tx);
+      const nonExistentUserId = "non-existent-user-id";
+
+      // 存在しないユーザーIDでも正常に動作する（空の結果を返す）
+      const batch =
+        await learningLogService.getPaginatedBatch(nonExistentUserId);
+
+      expect(batch.learningLogs).toHaveLength(0);
+      expect(batch.pageInfo.page).toBe(1);
+      expect(batch.pageInfo.perPage).toBe(5);
+      expect(batch.pageInfo.total).toBe(0);
+    });
+  });
+
+  test("大量データでのページネーション", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      // 全99件のダミーデータを作成
+      await createBulkLearningLogs(tx, userId, dummyLogs);
+
+      const learningLogService = new LearningLogService(tx);
+
+      // 中間のページをテスト（10ページ目）
+      const batch = await learningLogService.getPaginatedBatch(
+        userId,
+        10,
+        5,
+        "desc",
+      );
+
+      expect(batch.learningLogs).toHaveLength(5);
+      expect(batch.pageInfo.page).toBe(10);
+      expect(batch.pageInfo.total).toBe(99);
+
+      // 10ページ目の内容を確認（降順なので #54, #53, #52, #51, #50）
+      // 10ページ目 = skip: (10-1)*5 = 45件, take: 5件
+      // 降順なので #99から数えて 46-50番目 = #54, #53, #52, #51, #50
+      expect(batch.learningLogs[0].title).toBe("#54");
+      expect(batch.learningLogs[1].title).toBe("#53");
+      expect(batch.learningLogs[2].title).toBe("#52");
+      expect(batch.learningLogs[3].title).toBe("#51");
+      expect(batch.learningLogs[4].title).toBe("#50");
+    });
+  });
+
+  test("1件のみのデータでのページネーション", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      // 1件のみのダミーデータを作成
+      await createBulkLearningLogs(tx, userId, dummyLogs.slice(0, 1));
+
+      const learningLogService = new LearningLogService(tx);
+      const batch = await learningLogService.getPaginatedBatch(userId);
+
+      expect(batch.learningLogs).toHaveLength(1);
+      expect(batch.pageInfo.page).toBe(1);
+      expect(batch.pageInfo.perPage).toBe(5);
+      expect(batch.pageInfo.total).toBe(1);
+      expect(batch.learningLogs[0].title).toBe("#01");
+    });
+  });
+
+  test("perPageより少ないデータでのページネーション", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      // 3件のダミーデータを作成
+      await createBulkLearningLogs(tx, userId, dummyLogs.slice(0, 3));
+
+      const learningLogService = new LearningLogService(tx);
+      const batch = await learningLogService.getPaginatedBatch(
+        userId,
+        1,
+        5,
+        "desc",
+      );
+
+      expect(batch.learningLogs).toHaveLength(3);
+      expect(batch.pageInfo.page).toBe(1);
+      expect(batch.pageInfo.perPage).toBe(5);
+      expect(batch.pageInfo.total).toBe(3);
+
+      // 降順で3件表示
+      expect(batch.learningLogs[0].title).toBe("#03");
+      expect(batch.learningLogs[1].title).toBe("#02");
+      expect(batch.learningLogs[2].title).toBe("#01");
+    });
+  });
+});

--- a/tests/LearningLogService/getPaginatedBatch-sorting.spec.ts
+++ b/tests/LearningLogService/getPaginatedBatch-sorting.spec.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import {
+  createDummyLearningLogData,
+  createNullStartedAtLogData,
+} from "./helpers/test-data-generator";
+import { createTestUser, createBulkLearningLogs } from "./helpers/test-setup";
+
+describe("LearningLogService.getPaginatedBatch - ソート機能", () => {
+  const dummyLogs = createDummyLearningLogData();
+
+  test("昇順ソート", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+      await createBulkLearningLogs(tx, userId, dummyLogs);
+
+      const learningLogService = new LearningLogService(tx);
+      // 昇順ソートで取得
+      const batch = await learningLogService.getPaginatedBatch(
+        userId,
+        1,
+        5,
+        "asc",
+      );
+
+      expect(batch.learningLogs).toHaveLength(5);
+      expect(batch.sortOrder).toBe("asc");
+
+      // 昇順の場合、最古（#01）から順番に表示されることを確認
+      expect(batch.learningLogs[0].title).toBe("#01");
+      expect(batch.learningLogs[1].title).toBe("#02");
+      expect(batch.learningLogs[2].title).toBe("#03");
+      expect(batch.learningLogs[3].title).toBe("#04");
+      expect(batch.learningLogs[4].title).toBe("#05");
+    });
+  });
+
+  test("startedAtがnullのデータが先頭に表示される（降順）", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+
+      const learningLogService = new LearningLogService(tx);
+
+      // 通常のデータを3件作成
+      await createBulkLearningLogs(tx, userId, dummyLogs.slice(0, 3));
+
+      // startedAtがnullのデータを作成
+      const nullStartedAtLog = createNullStartedAtLogData();
+      await learningLogService.create(userId, nullStartedAtLog);
+
+      // 降順で取得
+      const batchDesc = await learningLogService.getPaginatedBatch(
+        userId,
+        1,
+        10,
+        "desc",
+      );
+
+      // startedAtがnullのデータが先頭に表示されることを確認
+      expect(batchDesc.learningLogs[0].title).toBe("#NULL");
+      expect(batchDesc.learningLogs[0].startedAt).toBeUndefined();
+    });
+  });
+
+  test("startedAtがnullのデータが先頭に表示される（昇順）", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+
+      const learningLogService = new LearningLogService(tx);
+
+      // 通常のデータを3件作成
+      await createBulkLearningLogs(tx, userId, dummyLogs.slice(0, 3));
+
+      // startedAtがnullのデータを作成
+      const nullStartedAtLog = createNullStartedAtLogData();
+      await learningLogService.create(userId, nullStartedAtLog);
+
+      // 昇順で取得
+      const batchAsc = await learningLogService.getPaginatedBatch(
+        userId,
+        1,
+        10,
+        "asc",
+      );
+
+      // 昇順でもstartedAtがnullのデータが先頭に表示されることを確認
+      expect(batchAsc.learningLogs[0].title).toBe("#NULL");
+      expect(batchAsc.learningLogs[0].startedAt).toBeUndefined();
+    });
+  });
+
+  test("複数のstartedAtがnullのデータの順序（createdAt、idでのソート）", async () => {
+    await runInRollbackTx(async (tx) => {
+      const { id: userId } = await createTestUser(tx);
+
+      const learningLogService = new LearningLogService(tx);
+
+      // 複数のstartedAtがnullのデータを作成
+      const nullLog1 = { ...createNullStartedAtLogData(), title: "#NULL1" };
+      const nullLog2 = { ...createNullStartedAtLogData(), title: "#NULL2" };
+      const nullLog3 = { ...createNullStartedAtLogData(), title: "#NULL3" };
+
+      // 順番に作成（createdAtが異なるようになる）
+      await learningLogService.create(userId, nullLog1);
+      await learningLogService.create(userId, nullLog2);
+      await learningLogService.create(userId, nullLog3);
+
+      // 降順で取得
+      const batchDesc = await learningLogService.getPaginatedBatch(
+        userId,
+        1,
+        10,
+        "desc",
+      );
+
+      // startedAtがnullのデータが作成順の逆順（createdAtの降順）で表示されることを確認
+      expect(batchDesc.learningLogs[0].title).toBe("#NULL3");
+      expect(batchDesc.learningLogs[1].title).toBe("#NULL2");
+      expect(batchDesc.learningLogs[2].title).toBe("#NULL1");
+
+      // 昇順で取得
+      const batchAsc = await learningLogService.getPaginatedBatch(
+        userId,
+        1,
+        10,
+        "asc",
+      );
+
+      // 昇順の場合は作成順（createdAtの昇順）で表示されることを確認
+      expect(batchAsc.learningLogs[0].title).toBe("#NULL1");
+      expect(batchAsc.learningLogs[1].title).toBe("#NULL2");
+      expect(batchAsc.learningLogs[2].title).toBe("#NULL3");
+    });
+  });
+});

--- a/tests/LearningLogService/helpers/common-mock-data.ts
+++ b/tests/LearningLogService/helpers/common-mock-data.ts
@@ -1,0 +1,70 @@
+import type { LearningLogInsertRequest } from "@/app/_types/LearningLog";
+
+/**
+ * CRUD操作テスト用の共通モックデータ
+ * 面白い日本語の学習体験記として作成
+ */
+
+/**
+ * 単一の学習ログデータ（基本的なCRUD操作テスト用）
+ */
+export const mockLearningLog: LearningLogInsertRequest = {
+  title: "電子珠算機に「おはよう世界」と挨拶を試みるも不発",
+  description: `• console.log なるものにて「Hello World」を表示せよとの御下命
+• 「コンソール」が何なのかわからず、字引にて調べて「魂を慰める台」と解釈し仏壇を探す
+• 結局、F12なる呪文で現れた「文字の世界」に言葉が刻まれることを発見し、活版印刷を超えた技術に感嘆`,
+  reflections: `• この電子珠算機は思考を読まず、正確な指令を要することを学習
+• 明日は「さようなら世界」も試してみたい`,
+  spentMinutes: 180,
+  startedAt: new Date("2025-08-11T09:00:00Z"),
+  endedAt: new Date("2025-08-11T20:30:00Z"),
+};
+
+/**
+ * 複数の学習ログデータ（配列での操作テスト用）
+ */
+export const mockLearningLogs: LearningLogInsertRequest[] = [
+  {
+    title: "電子珠算機に「おはよう世界」と挨拶を試みるも不発",
+    description: `• console.logなるもので「Hello World」を表示せよとの指令
+• 「コンソール」が何なのかわからず、「魂を慰める台」と解釈し仏壇を探す
+• 結局、F12なる呪文で現れた「文字の世界」に言葉が刻まれることを発見し、活版印刷を超えた技術に感嘆`,
+    reflections: `• この電子珠算機は思考を読まず、正確な指令を要することを学習
+• 明日は「さようなら世界」も試してみたい`,
+    spentMinutes: 180,
+    startedAt: new Date("2025-08-11T09:00:00Z"),
+    endedAt: new Date("2025-08-11T20:30:00Z"),
+  },
+  {
+    title: "変数なる得体の知れぬものとの格闘",
+    description: `• 「変数」は「変わる数」ではないと知り、漢学の勉強が役に立たず愕然
+• let、const、varを見て「きっと吉凶があるのだろう」と易占いで使い分けを決めた
+• 「=」が「等しい」ではなく「代入」だと知り「寺子屋の先生の墓前で謝罪せねば」と神妙になった`,
+    reflections: `• 変数とは値を入れる箱のようなものだと理解（米俵のイメージ）
+• varは古い書き方らしく、祟りが怖いので丁寧に扱うことにした`,
+    spentMinutes: 480,
+    startedAt: new Date("2025-08-12T12:30:00Z"),
+    endedAt: new Date("2025-08-12T23:00:00Z"),
+  },
+  {
+    title: "functionなる関数との邂逅で大混乱",
+    description: `• 引数(ひきすう)を「ひきかず」と読んで大恥をかく
+• 関数を呼び出すのに()が必要と知り「口の形を真似しているのか？」と「あー」の口で呼んでみた`,
+    reflections: `returnを忘れるとundefinedになることを痛感（何も返さないのは無礼）
+• 関数名は動詞で付けるのが良いらしいが、「御挨拶()」みたいな日本語関数名も作りたい`,
+    spentMinutes: 180,
+    startedAt: new Date("2025-08-13T18:30:00Z"),
+    endedAt: new Date("2025-08-13T21:00:00Z"),
+  },
+];
+
+/**
+ * オプションフィールドが未定義の学習ログデータ（型変換テスト用）
+ */
+export const mockLearningLogWithOptionalFields: LearningLogInsertRequest = {
+  title: "型変換テスト用ログ",
+  description: "null値の変換をテストしています",
+  reflections: "undefinedとnullの違いを確認中",
+  spentMinutes: 120,
+  // taskId, startedAt, endedAt は undefined（つまりDBには null で保存される）
+};

--- a/tests/LearningLogService/helpers/test-data-generator.ts
+++ b/tests/LearningLogService/helpers/test-data-generator.ts
@@ -1,0 +1,43 @@
+import type { LearningLogInsertRequest } from "@/app/_types/LearningLog";
+
+/**
+ * 学習ログのダミーデータの生成
+ * title: "#01", "#02", ..., "#99"
+ * description: 空文字 ""
+ * reflections: 空文字 ""
+ * 日付: 2025年2月1日から1日1件
+ */
+export const createDummyLearningLogData = (): LearningLogInsertRequest[] => {
+  const logs: LearningLogInsertRequest[] = [];
+  const baseDate = new Date("2025-02-01T09:30:00Z");
+
+  for (let i = 1; i <= 99; i++) {
+    const dayOffset = i - 1;
+    const startedAt = new Date(baseDate);
+    startedAt.setDate(baseDate.getDate() + dayOffset);
+
+    const endedAt = new Date(startedAt);
+    endedAt.setHours(startedAt.getHours() + 2); // 2時間後に終了
+
+    logs.push({
+      title: `#${String(i).padStart(2, "0")}`,
+      description: "",
+      reflections: "",
+      spentMinutes: 120,
+      startedAt,
+      endedAt,
+    });
+  }
+
+  return logs;
+};
+
+// startedAt が undefined（未設定）の学習ログデータを作成
+export const createNullStartedAtLogData = (): LearningLogInsertRequest => ({
+  title: "#NULL",
+  description: "",
+  reflections: "",
+  spentMinutes: 60,
+  startedAt: undefined, // startedAtをundefinedに設定
+  endedAt: undefined,
+});

--- a/tests/LearningLogService/helpers/test-setup.ts
+++ b/tests/LearningLogService/helpers/test-setup.ts
@@ -1,0 +1,62 @@
+import { UserService } from "@/app/_services/userService";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import type { DbClient } from "@/app/_types/Services";
+import type { LearningLogInsertRequest } from "@/app/_types/LearningLog";
+import { v4 as uuid } from "uuid";
+
+type TestUser = {
+  id: string;
+  name: string;
+};
+
+/**
+ * テスト用ユーザーを作成
+ */
+export const createTestUser = async (
+  tx: DbClient,
+  name: string = "検査 官太郎",
+): Promise<TestUser> => {
+  const id = uuid();
+  const userService = new UserService(tx);
+  await userService.createAsStudent(id, name);
+  return { id, name } satisfies TestUser;
+};
+
+// 指定ユーザーの学習ログを一括作成
+export const createBulkLearningLogs = async (
+  tx: DbClient,
+  userId: string,
+  logDataArray: LearningLogInsertRequest[],
+): Promise<void> => {
+  const learningLogService = new LearningLogService(tx);
+  for (const logData of logDataArray) {
+    await learningLogService.create(userId, logData);
+  }
+};
+
+// 複数のユーザを作成し、各ユーザーの学習ログを一括作成
+export const setupMultipleUsersWithLogs = async (
+  tx: DbClient,
+  userConfigs: Array<{
+    userName: string;
+    logCount: number;
+    startIndex?: number;
+  }>,
+  dummyLogs: LearningLogInsertRequest[],
+): Promise<TestUser[]> => {
+  const users: TestUser[] = [];
+
+  for (const config of userConfigs) {
+    const user = await createTestUser(tx, config.userName);
+    users.push(user);
+
+    const startIndex = config.startIndex || 0;
+    const logsToCreate = dummyLogs.slice(
+      startIndex,
+      startIndex + config.logCount,
+    );
+    await createBulkLearningLogs(tx, user.id, logsToCreate);
+  }
+
+  return users;
+};

--- a/tests/LearningLogService/tryGetById.spec.ts
+++ b/tests/LearningLogService/tryGetById.spec.ts
@@ -72,9 +72,13 @@ describe("LearningLogService tryGetById", () => {
       expect(selectedLog!.spentMinutes).toBe(mockLearningLog.spentMinutes);
 
       // (4) 選択していないフィールドは undefined であることを確認
-      expect(selectedLog!.title).toBeUndefined();
-      expect(selectedLog!.reflections).toBeUndefined();
-      expect(selectedLog!.userId).toBeUndefined();
+      //     - selectで除外されたフィールドの実行時チェックのため意図的に any 型にキャスト
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((selectedLog as any)!.title).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((selectedLog as any)!.reflections).toBeUndefined();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((selectedLog as any)!.userId).toBeUndefined();
     });
   });
 

--- a/tests/LearningLogService/tryGetById.spec.ts
+++ b/tests/LearningLogService/tryGetById.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import { UserService } from "@/app/_services/userService";
+import { mockLearningLog } from "./helpers/common-mock-data";
+import { v4 as uuid } from "uuid";
+import { Role } from "@prisma/client";
+
+describe("LearningLogService tryGetById", () => {
+  test("存在する学習ログを正常に取得できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      // (1) ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // (2) 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      // (3) tryGetByIdでの取得テスト
+      const retrievedLog = await learningLogService.tryGetById(createdLog.id);
+
+      // (4) 取得結果の検証
+      expect(retrievedLog).toBeDefined();
+      expect(retrievedLog!.id).toBe(createdLog.id);
+      expect(retrievedLog!.userId).toBe(userId);
+      expect(retrievedLog!.title).toBe(mockLearningLog.title);
+    });
+  });
+
+  test("存在しない学習ログを指定すると null が取得できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      const learningLogService = new LearningLogService(tx);
+      const nonExistentId = uuid();
+
+      const result = await learningLogService.tryGetById(nonExistentId);
+      expect(result).toBeNull();
+    });
+  });
+
+  test("selectオプションで指定フィールドのみを取得できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      // (1) ユーザー作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // (2) 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      // (3) selectオプションで id / description / spentMinutes のみを取得指定
+      const selectedLog = await learningLogService.tryGetById(createdLog.id, {
+        select: {
+          id: true,
+          description: true,
+          spentMinutes: true,
+        },
+      });
+      expect(selectedLog).toBeDefined();
+      expect(selectedLog!.id).toBe(createdLog.id);
+      expect(selectedLog!.description).toBe(mockLearningLog.description);
+      expect(selectedLog!.spentMinutes).toBe(mockLearningLog.spentMinutes);
+
+      // (4) 選択していないフィールドは undefined であることを確認
+      expect(selectedLog!.title).toBeUndefined();
+      expect(selectedLog!.reflections).toBeUndefined();
+      expect(selectedLog!.userId).toBeUndefined();
+    });
+  });
+
+  test("includeオプションでUserリレーションを含めて取得できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      // (1) ユーザー作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // (2) 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      // (3) includeオプションで User を含めて取得
+      const logWithUser = await learningLogService.tryGetById(createdLog.id, {
+        include: {
+          user: true,
+        },
+      });
+
+      // (4) 取得結果の検証
+      expect(logWithUser).toBeDefined();
+      expect(logWithUser!.id).toBe(createdLog.id);
+      expect(logWithUser!.userId).toBe(userId);
+      expect(logWithUser!.user).toBeDefined();
+      expect(logWithUser!.user.id).toBe(userId);
+      expect(logWithUser!.user.name).toBe(userName);
+      expect(logWithUser!.user.role).toBe(Role.STUDENT);
+    });
+  });
+});

--- a/tests/LearningLogService/update.spec.ts
+++ b/tests/LearningLogService/update.spec.ts
@@ -1,0 +1,152 @@
+import { describe, expect, test } from "vitest";
+import { runInRollbackTx } from "../setup/prisma.setup";
+import { LearningLogService } from "@/app/_services/learningLogService";
+import { UserService } from "@/app/_services/userService";
+import { mockLearningLog } from "./helpers/common-mock-data";
+import type { LearningLogUpdateRequest } from "@/app/_types/LearningLog";
+import {
+  LearningLogNotFoundError,
+  UserPermissionDeniedError,
+} from "@/app/_libs/errors";
+import { v4 as uuid } from "uuid";
+
+describe("LearningLogService update", () => {
+  test("学習ログを正常に更新できる", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      // 更新データ準備
+      const updateData: LearningLogUpdateRequest = {
+        id: createdLog.id,
+        title: "更新されたタイトル",
+        description: "更新された内容",
+        reflections: "更新された振り返り",
+        spentMinutes: 240,
+        startedAt: new Date("2025-08-14T10:00:00Z"),
+        endedAt: new Date("2025-08-14T14:00:00Z"),
+      };
+
+      // 更新実行（所有者として）
+      await learningLogService.update(userId, createdLog.id, updateData);
+
+      // 更新結果の確認
+      const updatedLog = await learningLogService.getByIdWithOwnershipCheck(
+        userId,
+        createdLog.id,
+      );
+      expect(updatedLog.title).toBe(updateData.title);
+      expect(updatedLog.description).toBe(updateData.description);
+      expect(updatedLog.reflections).toBe(updateData.reflections);
+      expect(updatedLog.spentMinutes).toBe(updateData.spentMinutes);
+      expect(updatedLog.startedAt).toEqual(updateData.startedAt);
+      expect(updatedLog.endedAt).toEqual(updateData.endedAt);
+    });
+  });
+
+  test("存在しない学習ログの更新でLearningLogNotFoundErrorが発生する", async () => {
+    await runInRollbackTx(async (tx) => {
+      const learningLogService = new LearningLogService(tx);
+      const nonExistentId = uuid();
+
+      const updateData: LearningLogUpdateRequest = {
+        id: nonExistentId,
+        title: "存在しないログの更新",
+        description: "これは失敗するはず",
+        reflections: "更新されない",
+        spentMinutes: 60,
+        startedAt: new Date(),
+        endedAt: new Date(),
+      };
+
+      await expect(
+        learningLogService.update(null, nonExistentId, updateData),
+      ).rejects.toThrow(LearningLogNotFoundError);
+    });
+  });
+
+  test("他のユーザーの学習ログ更新でUserPermissionDeniedErrorが発生する", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザA作成
+      const userAId = uuid();
+      const userAName = "品質 管理代";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userAId, userAName);
+
+      // ユーザB作成
+      const userBId = uuid();
+      const userBName = "不具合 退治丸";
+      await userService.createAsStudent(userBId, userBName);
+
+      // ユーザAの学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userAId,
+        mockLearningLog,
+      );
+
+      const updateData: LearningLogUpdateRequest = {
+        id: createdLog.id,
+        title: "不正な更新",
+        description: "他人のログを更新しようとしている",
+        reflections: "これは失敗するはず",
+        spentMinutes: 60,
+        startedAt: new Date(),
+        endedAt: new Date(),
+      };
+
+      // ユーザBがユーザAの学習ログを更新しようとする
+      await expect(
+        learningLogService.update(userBId, createdLog.id, updateData),
+      ).rejects.toThrow(UserPermissionDeniedError);
+    });
+  });
+
+  test("userId=nullで所有権チェックをスキップする", async () => {
+    await runInRollbackTx(async (tx) => {
+      // ユーザ作成
+      const userId = uuid();
+      const userName = "検査 官太郎";
+      const userService = new UserService(tx);
+      await userService.createAsStudent(userId, userName);
+
+      // 学習ログ作成
+      const learningLogService = new LearningLogService(tx);
+      const createdLog = await learningLogService.create(
+        userId,
+        mockLearningLog,
+      );
+
+      const updateData: LearningLogUpdateRequest = {
+        id: createdLog.id,
+        title: "管理者による更新",
+        description: "所有権チェックなしの更新",
+        reflections: "管理者権限での変更",
+        spentMinutes: 300,
+        startedAt: new Date("2025-08-15T08:00:00Z"),
+        endedAt: new Date("2025-08-15T13:00:00Z"),
+      };
+
+      // userId=nullで更新（所有権チェックをスキップ）
+      await learningLogService.update(null, createdLog.id, updateData);
+
+      // 更新結果の確認
+      const updatedLog = await learningLogService.getByIdWithOwnershipCheck(
+        null,
+        createdLog.id,
+      );
+      expect(updatedLog.title).toBe("管理者による更新");
+      expect(updatedLog.description).toBe("所有権チェックなしの更新");
+    });
+  });
+});

--- a/tests/UserService/createAsStudent.spec.ts
+++ b/tests/UserService/createAsStudent.spec.ts
@@ -2,16 +2,17 @@ import { describe, expect, test, vitest } from "vitest";
 import { runInRollbackTx } from "../setup/prisma.setup";
 import { UserService } from "@/app/_services/userService";
 import { Role } from "@prisma/client";
+import { v4 as uuid } from "uuid";
 
 describe("UserService", () => {
-  test("受講生ロールのユーザーの新規作成", async () => {
+  test("create - 受講生ロールのユーザーの新規作成", async () => {
     await runInRollbackTx(async (tx) => {
       const userService = new UserService(tx);
 
       const initUserNum = await userService.count();
 
       // ユーザ（受講生）の新規作成
-      const id = "cccccccc-cccc-cccc-cccc-cccccccccccc";
+      const id = uuid();
       const name = "検査 官太郎";
       await userService.createAsStudent(id, name);
       expect(await userService.count()).toBe(initUserNum + 1);


### PR DESCRIPTION
## 実装概要

Issue #51 に基づいた学習ログ（LearningLog）の取得・更新・削除などを担うサービス層（バックエンド）の実装です。

## レビューについて

この PR に含まれるテストファイル（`*.spec.ts`）は  Claude Code で作成したもので、基本的な動作確認は済んでいます。レビューでは `learningLogService.ts` 本体を重点的に見ていただけると助かります 🙇

resolve #51 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 学習ログの完全なCRUDとページネーションを提供するサービスを追加
  - ユーザー名検索機能を追加

- バグ修正
  - 並び替えで開始時刻未設定のログを常に先頭に表示する挙動を安定化
  - UUIDバリデーションのメッセージを日本語化

- スタイル
  - 学習ログページのレイアウト（余白・幅）を調整

- ドキュメント
  - TypeScriptの型付けガイドラインを追記

- チョア
  - エディタ設定・バージョン管理設定を更新
  - テスト用シードデータを固定UUIDに変更

- テスト
  - 学習ログのCRUD、権限制御、並び替え、ページネーションを網羅する多数のテストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->