### PR TITLE
学習ログの更新機能

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,8 +139,12 @@ DIRECT_URL=postgresql://postgres:postgres@127.0.0.1:54322/postgres
 - Code comments should be in Japanese when appropriate
 
 ### Import Paths
-- Use `@/` alias for src directory imports
-- Organize imports: external libraries first, then internal modules
+- **Same functional module**: Use relative paths for closely related files (same page.tsx and its _components, _types, _hooks, etc.)
+  - Example: `import { Component } from "../_components/Component"`
+- **Different functional modules**: Use `@/` alias for shared modules and distant imports 
+  - Example: `import { service } from "@/app/_services/someService"`
+- **External libraries**: Always import first, before internal modules
+- This approach balances readability and maintainability by keeping related files easily traceable through relative paths while using aliases for cross-module dependencies
 
 ### Component Structure
 - Functional components with TypeScript

--- a/src/app/(private)/learning-logs/[logId]/page.tsx
+++ b/src/app/(private)/learning-logs/[logId]/page.tsx
@@ -1,0 +1,38 @@
+import prisma from "@/app/_libs/prisma";
+import { authenticateAppUser } from "@/app/_libs/authenticateUser";
+import { LearningLogService, toAppLearningLog } from "@/app/_services/learningLogService";
+
+// UIコンポーネント・アイコン
+import { ErrorPage } from "@/app/_components/ErrorPage";
+import { LearningLogUpdatePage } from "../_components/LearningLogUpdatePage";
+
+// 型定義・バリデーションスキーマ
+import { LearningLogNotFoundError, UserPermissionDeniedError } from "@/app/_libs/errors";
+
+// ユーティリティ
+import { dumpError } from "@/app/_libs/dumpException";
+
+export const dynamic = "force-dynamic";
+
+type RouteParams = { logId: string };
+type Props = {
+  params: Promise<RouteParams>;
+};
+
+const Page: React.FC<Props> = async ({ params }) => {
+  try {
+    const { logId } = await params;
+    const { id: userId } = await authenticateAppUser();
+    const learningLogService = new LearningLogService(prisma);
+    const dbLearningLog = await learningLogService.getByIdWithOwnershipCheck(userId, logId);
+    return <LearningLogUpdatePage initValues={toAppLearningLog(dbLearningLog)} />;
+  } catch (e) {
+    if (e instanceof LearningLogNotFoundError || e instanceof UserPermissionDeniedError)
+      return <ErrorPage message="指定された学習ログは存在しないか、アクセス権がありません。" />;
+    dumpError(e, "学習ログ");
+    const errMsg = "学習ログの取得処理に失敗しました。しばらく時間をおいてから再試行してください。";
+    return <ErrorPage message={errMsg} />;
+  }
+};
+
+export default Page;

--- a/src/app/(private)/learning-logs/_actions/learningLogInsertAction.ts
+++ b/src/app/(private)/learning-logs/_actions/learningLogInsertAction.ts
@@ -11,7 +11,6 @@ import type { LearningLogInsertRequest } from "@/app/_types/LearningLog";
 
 // ユーティリティ
 import { dumpError } from "@/app/_libs/dumpException";
-import { isDevelopmentEnv } from "@/app/_configs/app-config";
 import { LearningLogService } from "@/app/_services/learningLogService";
 
 // ServerActionの戻り値
@@ -30,11 +29,6 @@ export const learningLogInsertAction = async (
 ): Promise<LearningLogInsertActionResult> => {
   let user: AppUser | null = null;
   try {
-    // TODO:デバッグとUX調整のための遅延（本番では削除）
-    if (isDevelopmentEnv) {
-      await new Promise((resolve) => setTimeout(resolve, 1500));
-    }
-
     // バックエンド認証（クライアント偽装対策）
     user = await authenticateAppUser();
 

--- a/src/app/(private)/learning-logs/_actions/learningLogUpdateAction.ts
+++ b/src/app/(private)/learning-logs/_actions/learningLogUpdateAction.ts
@@ -1,0 +1,55 @@
+"use server";
+
+// DB接続・サービス層・認証
+import prisma from "@/app/_libs/prisma";
+import { authenticateAppUser } from "@/app/_libs/authenticateUser";
+
+// 型定義・バリデーションスキーマ
+import type { User as AppUser } from "@prisma/client";
+import type { LearningLogUpdateRequest } from "@/app/_types/LearningLog";
+import { learningLogUpdateRequestSchema } from "@/app/_types/LearningLog";
+
+// ユーティリティ
+import { dumpError } from "@/app/_libs/dumpException";
+import { LearningLogService } from "@/app/_services/learningLogService";
+
+// ServerActionの戻り値
+type LearningLogUpdateActionResult =
+  | { success: true; errorMessageForUser?: never }
+  | { success: false; errorMessageForUser: string };
+
+/**
+ * 学習ログを更新作成する Server Action
+ *
+ * @param learningLogUpdateRequest - 学習ログ新規作成リクエスト
+ * @returns 学習ログ新規作成処理結果
+ */
+export const learningLogUpdateAction = async (
+  learningLogUpdateRequest: LearningLogUpdateRequest,
+): Promise<LearningLogUpdateActionResult> => {
+  let user: AppUser | null = null;
+  try {
+    // バックエンド認証（クライアント偽装対策）
+    user = await authenticateAppUser();
+
+    // バックエンドバリデーション（引数改竄対策）
+    learningLogUpdateRequest = learningLogUpdateRequestSchema.parse(learningLogUpdateRequest);
+    const { id: logId } = learningLogUpdateRequest;
+
+    // 学習ログの更新処理（LearningLogService）
+    const learningLogService = new LearningLogService(prisma);
+    await learningLogService.update(user.id, logId, learningLogUpdateRequest);
+
+    return { success: true } satisfies LearningLogUpdateActionResult;
+  } catch (e) {
+    dumpError(e, "学習ログの更新処理 (ServerAction)", {
+      userId: user?.id,
+      learningLogUpdateRequest: learningLogUpdateRequest,
+    });
+    return {
+      success: false,
+      errorMessageForUser:
+        "バックエンドで発生した予期せぬエラーにより学習ログの更新処理に失敗しました。再度お試しください。",
+    } satisfies LearningLogUpdateActionResult;
+  }
+};

--- a/src/app/(private)/learning-logs/_components/LearningLogUpdatePage.tsx
+++ b/src/app/(private)/learning-logs/_components/LearningLogUpdatePage.tsx
@@ -1,0 +1,131 @@
+"use client";
+
+// React と フォームライブラリ
+import { useCallback, useTransition, useMemo } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, FormProvider } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+
+// ServerActions / API系
+import { learningLogUpdateAction } from "../_actions/learningLogUpdateAction";
+
+// UIコンポーネント・アイコン
+import { PageTitle } from "@/app/_components/PageTitle";
+import { LearningLogEditForm } from "./LearningLogEditForm";
+import { Button } from "@/app/_components/ui/button";
+
+// 型定義・バリデーションスキーマ
+import { learningLogUpdateRequestSchema } from "@/app/_types/LearningLog";
+import type { LearningLog } from "@/app/_types/LearningLog";
+
+type LearningLogUpdateFormValues = z.input<typeof learningLogUpdateRequestSchema>;
+
+// 定数
+const c_Root = "root" as const;
+
+type Props = {
+  initValues: LearningLog;
+};
+
+export const LearningLogUpdatePage: React.FC<Props> = ({ initValues }) => {
+  const router = useRouter();
+
+  const [isPending, startTransition] = useTransition();
+
+  // LearningLog を LearningLogUpdateRequest の形式に変換
+  const convertToFormValues = useCallback(
+    (learningLog: LearningLog): LearningLogUpdateFormValues => {
+      return {
+        id: learningLog.id,
+        taskId: learningLog.taskId,
+        title: learningLog.title,
+        description: learningLog.description,
+        reflections: learningLog.reflections,
+        spentMinutes: learningLog.spentMinutes !== 0 ? learningLog.spentMinutes : undefined,
+        startedAt: learningLog.startedAt,
+        endedAt: learningLog.endedAt,
+      };
+    },
+    [],
+  );
+
+  const form = useForm<LearningLogUpdateFormValues>({
+    resolver: zodResolver(learningLogUpdateRequestSchema),
+    mode: "onChange",
+    defaultValues: convertToFormValues(initValues),
+  });
+
+  // リセット機能（初期値に戻す）
+  const handleReset = useCallback(() => {
+    form.reset(convertToFormValues(initValues));
+  }, [form, initValues, convertToFormValues]);
+
+  // フォームの Submit 処理
+  const onSubmit = useCallback(
+    async (formValues: LearningLogUpdateFormValues) => {
+      form.clearErrors(c_Root);
+      try {
+        const req = learningLogUpdateRequestSchema.parse(formValues);
+        const result = await learningLogUpdateAction(req);
+        if (result.success) {
+          startTransition(() => {
+            router.push("/learning-logs");
+          });
+          return;
+        }
+        form.setError(c_Root, {
+          message: result.errorMessageForUser ?? "バックエンドで学習ログの更新処理に失敗しました",
+        });
+      } catch {
+        form.setError(c_Root, {
+          message: "学習ログの更新に予期せず失敗しました",
+        });
+      }
+    },
+    [form, router],
+  );
+
+  const handleSubmit = useMemo(() => form.handleSubmit(onSubmit), [form, onSubmit]);
+
+  const submitButtonText = useMemo(
+    () => (isPending ? "画面遷移中..." : form.formState.isSubmitting ? "更新中..." : "更新"),
+    [isPending, form.formState.isSubmitting],
+  );
+
+  const formLocked = useMemo(
+    () => isPending || form.formState.isSubmitting,
+    [isPending, form.formState.isSubmitting],
+  );
+
+  const submitDisabled = useMemo(
+    () => isPending || form.formState.isSubmitting || !form.formState.isValid,
+    [isPending, form.formState.isSubmitting, form.formState.isValid],
+  );
+
+  return (
+    <div className="mx-auto my-4 w-full max-w-lg space-y-4 px-4 lg:px-0">
+      <PageTitle>学習ログの編集</PageTitle>
+      <FormProvider {...form}>
+        <div className="space-y-4">
+          <LearningLogEditForm
+            onSubmit={handleSubmit}
+            formLocked={formLocked}
+            submitDisabled={submitDisabled}
+            submitButtonText={submitButtonText}
+            errorMessage={form.formState.errors.root?.message}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            className="w-full"
+            onClick={handleReset}
+            disabled={isPending || form.formState.isSubmitting}
+          >
+            リセット
+          </Button>
+        </div>
+      </FormProvider>
+    </div>
+  );
+};

--- a/src/app/_components/FormTextAreaField.tsx
+++ b/src/app/_components/FormTextAreaField.tsx
@@ -140,7 +140,7 @@ const FormTextAreaFieldComponent = <T extends FieldValues>({
       </div>
       <div className="relative">
         <Textarea
-          {...textareaProps}
+          {...restInputProps}
           id={fieldKey}
           name={field.name}
           ref={field.ref}

--- a/src/app/_components/FormTextAreaField.tsx
+++ b/src/app/_components/FormTextAreaField.tsx
@@ -50,6 +50,15 @@ const FormTextAreaFieldComponent = <T extends FieldValues>({
 
   const errMsg = getFieldErrorMessage(errors, fieldKey);
 
+  // 制御系キーを除外して先にスプレッドするために分離
+  const {
+    onChange: _onChange,
+    onBlur: _onBlur,
+    value: _value,
+    defaultValue: _defaultValue,
+    ...restInputProps
+  } = textareaProps;
+
   // テンプレート機能の状態管理、テンプレート機能の有効性判定
   const [hasTemplate, setHasTemplate] = useState(false);
   const [dynamicPlaceholder, setDynamicPlaceholder] = useState<string>("");
@@ -131,6 +140,7 @@ const FormTextAreaFieldComponent = <T extends FieldValues>({
       </div>
       <div className="relative">
         <Textarea
+          {...textareaProps}
           id={fieldKey}
           name={field.name}
           ref={field.ref}
@@ -141,7 +151,6 @@ const FormTextAreaFieldComponent = <T extends FieldValues>({
           placeholder={finalPlaceholder}
           disabled={isDisabled}
           className="pr-12"
-          {...textareaProps}
         />
         {enableTemplate && (
           <div className="absolute top-2 right-2 flex">

--- a/src/app/_components/FormTextField.tsx
+++ b/src/app/_components/FormTextField.tsx
@@ -3,7 +3,7 @@
 import type { InputHTMLAttributes } from "react";
 import type { FieldValues, Path, PathValue } from "react-hook-form";
 
-import React, { useState, useEffect, useMemo, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import { useFormContext, useFormState, useController, useWatch } from "react-hook-form";
 import { LuSave, LuFileText } from "react-icons/lu";
 
@@ -51,6 +51,15 @@ const FormTextFieldComponent = <T extends FieldValues>({
 
   const errMsg = getFieldErrorMessage(errors, fieldKey);
 
+  // 制御系キーを除外して先にスプレッドするために分離
+  const {
+    onChange: _onChange,
+    onBlur: _onBlur,
+    value: _value,
+    defaultValue: _defaultValue,
+    ...restInputProps
+  } = inputProps;
+
   // テンプレート機能の状態管理、テンプレート機能の有効性判定
   const [hasTemplate, setHasTemplate] = useState(false);
   const [dynamicPlaceholder, setDynamicPlaceholder] = useState<string>("");
@@ -64,14 +73,12 @@ const FormTextFieldComponent = <T extends FieldValues>({
   const finalPlaceholder = placeholder ?? dynamicPlaceholder;
 
   // 入力フィールドが変更されたときの処理
-  // RHFのバリデーション発火と、Props に registerOnChange があればそれも発火
+  //  - number のときは "" を許容し、入力中は文字列のまま RHF に渡す（全消しを安定させる）
+  //  - blur で数値/undefined に確定する
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (inputType === "number") {
-        // 数値型の場合、空文字 を undefined に変換して RHF に渡す
-        const raw = e.target.value;
-        const parsed = raw === "" ? undefined : Number(raw);
-        field.onChange(parsed as PathValue<T, Path<T>>);
+        field.onChange(e.target.value as unknown as PathValue<T, Path<T>>);
       } else {
         field.onChange(e);
       }
@@ -80,8 +87,8 @@ const FormTextFieldComponent = <T extends FieldValues>({
     [field, registerOnChange, inputType],
   );
 
-  // 入力フィールドからフォーカスアウトされたときの処理
-  // RHFのバリデーション発火と、Props に registerOnBlur があればそれも発火
+  // 入力フィールドが変更されたときの処理
+  //  - number のときは "" を許容し、入力中は文字列のまま RHF に渡す（全消しを安定させる）
   const handleBlur = useCallback(
     (e: React.FocusEvent<HTMLInputElement>) => {
       field.onBlur();
@@ -148,6 +155,7 @@ const FormTextFieldComponent = <T extends FieldValues>({
 
       <div className="relative">
         <Input
+          {...restInputProps}
           id={fieldKey}
           name={field.name}
           ref={field.ref}
@@ -157,7 +165,6 @@ const FormTextFieldComponent = <T extends FieldValues>({
           aria-invalid={!!errMsg}
           placeholder={finalPlaceholder}
           disabled={isDisabled}
-          {...inputProps}
         />
 
         {enableTemplate && (

--- a/src/app/_components/FormTextField.tsx
+++ b/src/app/_components/FormTextField.tsx
@@ -74,7 +74,6 @@ const FormTextFieldComponent = <T extends FieldValues>({
 
   // 入力フィールドが変更されたときの処理
   //  - number のときは "" を許容し、入力中は文字列のまま RHF に渡す（全消しを安定させる）
-  //  - blur で数値/undefined に確定する
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
       if (inputType === "number") {

--- a/src/app/_services/learningLogService.ts
+++ b/src/app/_services/learningLogService.ts
@@ -189,10 +189,11 @@ class LearningLogService {
     data: LearningLogUpdateRequest,
   ): Promise<LearningLog> {
     await this.getByIdWithOwnershipCheck(userId, logId);
+    const { id: _omitId, ...updateData } = data; // id は更新不可なので除去
     const updatedLearningLog = await this.prisma.learningLog.update({
       where: { id: logId },
       data: {
-        ...data,
+        ...updateData,
         taskId: data.taskId ?? null,
         startedAt: data.startedAt ?? null,
         endedAt: data.endedAt ?? null,

--- a/src/app/_services/learningLogService.ts
+++ b/src/app/_services/learningLogService.ts
@@ -1,11 +1,5 @@
-import {
-  Prisma as PRS,
-  LearningLog as PrismaLearningLog,
-} from "@prisma/client";
-import {
-  LearningLogNotFoundError,
-  UserPermissionDeniedError,
-} from "@/app/_libs/errors";
+import { Prisma as PRS, LearningLog as PrismaLearningLog } from "@prisma/client";
+import { LearningLogNotFoundError, UserPermissionDeniedError } from "@/app/_libs/errors";
 import {
   SortOrder,
   LearningLog,
@@ -31,9 +25,7 @@ export type LearningLogReturnType<
  * PrismaのLearningLogモデルからLearningLog型への変換
  * （createdAt を除去して、特定属性を null から undefined に変換）
  */
-const toAppLearningLog = (
-  prismaLearningLog: PrismaLearningLog,
-): LearningLog => {
+export const toAppLearningLog = (prismaLearningLog: PrismaLearningLog): LearningLog => {
   const { createdAt, taskId, startedAt, endedAt, ...rest } = prismaLearningLog;
   return {
     ...rest,
@@ -100,10 +92,7 @@ class LearningLogService {
     logId: string,
     options: { select: U },
   ): Promise<PRS.LearningLogGetPayload<{ select: U }> | null>;
-  public async tryGetById<
-    T extends PRS.LearningLogInclude,
-    U extends PRS.LearningLogSelect,
-  >(
+  public async tryGetById<T extends PRS.LearningLogInclude, U extends PRS.LearningLogSelect>(
     logId: string,
     options?: LearningLogReturnType<T, U>,
   ): Promise<
@@ -180,10 +169,7 @@ class LearningLogService {
   }
 
   // 新規作成 [Create]
-  public async create(
-    userId: string,
-    data: LearningLogInsertRequest,
-  ): Promise<LearningLog> {
+  public async create(userId: string, data: LearningLogInsertRequest): Promise<LearningLog> {
     const createdLearningLog = await this.prisma.learningLog.create({
       data: {
         ...data,


### PR DESCRIPTION
既存の学習ログを更新する機能（フロントエンド＆バックエンド）を実装しました。

- `http://localhost:3000/learning-logs` にアクセスし、テーブルから任意の行（学習ログ）を選択すると編集画面に移動します。
- 開始時刻と終了時刻を15分刻みで扱う本UIとの整合のとれたデータを使用する必要があるため、動作検証の際には `npx prisma db seed` を再実行してください（初回のみ）。 

`learningLogService.ts` の変更は、実質的には `toAppLearningLog` 関数に `export` を付加しただけです。その他は、フォーマッタ設定が変更になったことによる改行位置の変更であり、このファイルのレビューは不要です。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - 学習ログ編集ページとクライアントUIを追加。編集・バリデーション・リセット・保存後の遷移に対応。
  - 学習ログ更新のサーバーアクションを追加し、成功/失敗の結果を返却。
- バグ修正
  - 数値入力で空文字を許容する挙動に改善。
  - テキスト/テキストエリアの内部制御と外部プロップの衝突を防止。
  - 更新処理でIDが上書きされないよう保護。
- ドキュメント
  - インポートパスガイドを詳細化し、相対パスとエイリアスの使い分けを明確化。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->